### PR TITLE
gbconv: add bounds checking.

### DIFF
--- a/include/gbconv.h
+++ b/include/gbconv.h
@@ -4,6 +4,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-size_t gbconv8(const char *src, char *dst, size_t dstlen);
+size_t gbconv8(const char *src, size_t srclen, char *dst, size_t dstlen);
 
 #endif

--- a/util/gbconv.c
+++ b/util/gbconv.c
@@ -3096,7 +3096,7 @@ static uint16_t gbk_to_index(char byte1, char byte2)
     return result - 0x2000;
 }
 
-size_t gbconv8(const char *src, char *dst, size_t dstlen)
+size_t gbconv8(const char *src, size_t srclen, char *dst, size_t dstlen)
 {
 
 #define gbconv8_FILL_DEST(value) \
@@ -3108,12 +3108,13 @@ size_t gbconv8(const char *src, char *dst, size_t dstlen)
         remainbuf--;             \
     }
 
+    const char *endsrc = src + srclen;
     const char *cursrc = src;
     char *curdst = dst;
     size_t remainbuf = dstlen;
     size_t len = 0;
     char byte1, byte2;
-    while (*cursrc)
+    while (cursrc < endsrc && *cursrc)
     {
         byte1 = *cursrc;
         if ((byte1 & 0x80) == 0x00)

--- a/util/misc.c
+++ b/util/misc.c
@@ -98,7 +98,7 @@ void gbk2utf8(char* in, size_t inlen, char* out, size_t outlen) {
         iconv_close(_cd);
     }
 #elif defined(ENABLE_GBCONV)
-    gbconv8(in, out, outlen);
+    gbconv8(in, inlen, out, outlen);
 #else
     memmove(out, in, inlen);
 #endif


### PR DESCRIPTION
有的时候服务器通知文本的末尾会出现乱码，测试发现服务器返回的数据结尾是不包括 '\0' 结束符的。
给 gbconv 加上边界检查即可解决此问题。