### PR TITLE
fix hex2char reverse and no-auto-reauth wrong value

### DIFF
--- a/config.c
+++ b/config.c
@@ -260,7 +260,7 @@ RESULT save_config_file() {
     conf_parser_add_value("if-impl", get_if_impl()->name);
     conf_parser_add_value("max-fail", my_itoa(g_prog_config.max_failures, itoa_buf, 10));
     conf_parser_add_value("max-retries", my_itoa(g_prog_config.max_retries, itoa_buf, 10));
-    conf_parser_add_value("no-auto-reauth", g_prog_config.restart_on_logoff ? "1" : "0");
+    conf_parser_add_value("no-auto-reauth", g_prog_config.restart_on_logoff ? "0" : "1");
     conf_parser_add_value("wait-after-fail", my_itoa(g_prog_config.wait_after_fail_secs, itoa_buf, 10));
     conf_parser_add_value("stage-timeout", my_itoa(g_prog_config.stage_timeout, itoa_buf, 10));
     conf_parser_add_value("proxy-lan-iface", g_proxy_config.lan_ifname);

--- a/util/misc.c
+++ b/util/misc.c
@@ -39,8 +39,8 @@ uint8_t char2hex(const char* str) {
 
 void hex2char(uint8_t hex, char* out) {
 #define HEX2LOWER(digit) (((digit) >= 0xa) ? ((digit) - 0xa + 'a') : ((digit) + '0'))
-    out[0] = HEX2LOWER(hex & 0xf);
-    out[1] = HEX2LOWER((hex & 0xf0) >> 4);
+    out[0] = HEX2LOWER((hex & 0xf0) >> 4);
+    out[1] = HEX2LOWER(hex & 0xf);
 }
 
 char* my_itoa(int val, char* buf, uint32_t radix) {


### PR DESCRIPTION
保存配置文件后发现 `rj-option` 字符反转了，比如原本是 `79:02`，保存后变成了 `97:20`。
`no-auto-reauth` 和 `restart_on_logoff ` 的逻辑值是相反的，保存时也应该反过来。