### PR TITLE
Fix crash on DHCP double auth and some other memory issues

### DIFF
--- a/config.c
+++ b/config.c
@@ -66,8 +66,8 @@ RESULT parse_cmdline_conf_file(int argc, char* argv[]) {
                 return FAILURE;
             } else {
                 int _len = strnlen(argv[i + 1], MAX_PATH);
-                g_prog_config.conffile = (char*)malloc(_len);
-                strncpy(g_prog_config.conffile, argv[i + 1], _len);
+                g_prog_config.conffile = (char*)malloc(_len + 1);
+                strncpy(g_prog_config.conffile, argv[i + 1], _len + 1);
             }
         }
     }

--- a/config.c
+++ b/config.c
@@ -67,7 +67,8 @@ RESULT parse_cmdline_conf_file(int argc, char* argv[]) {
             } else {
                 int _len = strnlen(argv[i + 1], MAX_PATH);
                 g_prog_config.conffile = (char*)malloc(_len + 1);
-                strncpy(g_prog_config.conffile, argv[i + 1], _len + 1);
+                strncpy(g_prog_config.conffile, argv[i + 1], _len);
+                g_prog_config.conffile[_len] = '\0';
             }
         }
     }

--- a/if_impl/if_impl.c
+++ b/if_impl/if_impl.c
@@ -42,7 +42,7 @@ void print_if_impl_list() {
  * if no name is specified.
  */
 static int impl_name_cmp(void* to_find, void* vimpl) {
-    return to_find ? memcmp(to_find, IMPL->name, strlen(IMPL->name)) : 0;
+    return to_find ? strcmp(to_find, IMPL->name) : 0;
 }
 
 RESULT select_if_impl(const char* name) {

--- a/packet_plugin/packet_plugin.c
+++ b/packet_plugin/packet_plugin.c
@@ -33,7 +33,7 @@ int init_packet_plugin_list() {
 }
 
 static int plugin_name_cmp(void* to_find, void* curr) {
-    return memcmp(to_find, ((PACKET_PLUGIN*)curr)->name, strlen(((PACKET_PLUGIN*)curr)->name));
+    return strcmp(to_find, ((PACKET_PLUGIN*)curr)->name);
 }
 
 RESULT select_packet_plugin(const char* name) {

--- a/packet_plugin/rjv3/packet_plugin_rjv3.c
+++ b/packet_plugin/rjv3/packet_plugin_rjv3.c
@@ -230,7 +230,7 @@ static RESULT rjv3_process_success(struct _packet_plugin* this, ETH_EAP_FRAME* f
              * once the state transition is finished. We need to keep it
              * in case DHCP fails and we need to start heartbeating.
              */
-            PRIV->last_recv_packet = frame_duplicate(frame);
+            PRIV->duplicated_packet = frame_duplicate(frame);
             system(PRIV->dhcp_script);
 
             /* Try right after the script ends */

--- a/packet_plugin/rjv3/packet_plugin_rjv3.c
+++ b/packet_plugin/rjv3/packet_plugin_rjv3.c
@@ -230,6 +230,9 @@ static RESULT rjv3_process_success(struct _packet_plugin* this, ETH_EAP_FRAME* f
              * once the state transition is finished. We need to keep it
              * in case DHCP fails and we need to start heartbeating.
              */
+            if (PRIV->duplicated_packet != NULL) {
+                free_frame(&PRIV->duplicated_packet);
+            }
             PRIV->duplicated_packet = frame_duplicate(frame);
             system(PRIV->dhcp_script);
 

--- a/packet_plugin/rjv3/packet_plugin_rjv3_priv.c
+++ b/packet_plugin/rjv3/packet_plugin_rjv3_priv.c
@@ -504,8 +504,8 @@ void rjv3_start_secondary_auth(void* vthis) {
     if (IS_FAIL(rjv3_get_dhcp_lease(this, &_tmp_dhcp_lease))) {
         PRIV->dhcp_count++;
         if (PRIV->dhcp_count > PRIV->max_dhcp_count) {
-            rjv3_process_result_prop(PRIV->last_recv_packet); // Loads of texts
-            free_frame(&PRIV->last_recv_packet); // Duplicated in process_success
+            rjv3_process_result_prop(PRIV->duplicated_packet); // Loads of texts
+            free_frame(&PRIV->duplicated_packet); // Duplicated in process_success
             schedule_alarm(1, rjv3_send_keepalive_timed, this);
             PR_ERR("无法获取 IPv4 地址等信息，将不会进行第二次认证而直接开始心跳");
         } else {
@@ -515,7 +515,7 @@ void rjv3_start_secondary_auth(void* vthis) {
         return;
     } else {
         PR_INFO("DHCP 完成，正在开始第二次认证");
-        free_frame(&PRIV->last_recv_packet); // Duplicated in process_success
+        free_frame(&PRIV->duplicated_packet); // Duplicated in process_success
         switch_to_state(EAP_STATE_START_SENT, NULL);
         return;
     }

--- a/packet_plugin/rjv3/packet_plugin_rjv3_priv.h
+++ b/packet_plugin/rjv3/packet_plugin_rjv3_priv.h
@@ -126,6 +126,7 @@ typedef struct _packet_plugin_rjv3_priv {
     int succ_count;
     int dhcp_count; // Used in double auth
     ETH_EAP_FRAME* last_recv_packet;
+    ETH_EAP_FRAME* duplicated_packet; // Used in double auth
 } rjv3_priv;
 
 RESULT rjv3_append_priv(struct _packet_plugin* this, ETH_EAP_FRAME* frame);


### PR DESCRIPTION
主要变更：

- 单独存储 DHCP 二次认证产生的帧副本
- 修复了 `AddressSanitizer` 检测到的其他内存错误

在学校使用 minieap 进行锐捷认证时发现使用 DHCP 二次认证方式会导致程序崩溃（glibc 检测到运行时错误主动退出），随后使用 `AddressSanitizer` 进行调试，定位到了问题：在 DHCP 二次认证等待时（`DHCP 可能尚未完成，将继续等待……`），如果接收到新的 EAP 帧，会导致二次认证产生的副本帧的指针被覆盖，二次认证错误地释放了 EAP 状态机管理的帧，进而导致 EAP 状态机使用已经被释放的内存（`heap-use-after-free`）。