### PR TITLE
小修小补

### DIFF
--- a/config.c
+++ b/config.c
@@ -65,10 +65,7 @@ RESULT parse_cmdline_conf_file(int argc, char* argv[]) {
                 PR_ERR("--conf-file必须有一个参数");
                 return FAILURE;
             } else {
-                int _len = strnlen(argv[i + 1], MAX_PATH);
-                g_prog_config.conffile = (char*)malloc(_len + 1);
-                strncpy(g_prog_config.conffile, argv[i + 1], _len);
-                g_prog_config.conffile[_len] = '\0';
+                g_prog_config.conffile = strndup(argv[i + 1], MAX_PATH);
             }
         }
     }

--- a/config.c
+++ b/config.c
@@ -132,13 +132,13 @@ static void parse_one_opt(const char* option, const char* argument) {
     } else if (ISOPT("password")) {
         COPY_N_ARG_TO(g_eap_config.password, PASSWORD_MAX_LEN);
     } else if (ISOPT("nic")) {
-        COPY_N_ARG_TO(g_prog_config.ifname, IFNAMSIZ);
+        COPY_N_ARG_TO(g_prog_config.ifname, IFNAMSIZ - 1);
     } else if (ISOPT("daemonize")) {
         g_prog_config.daemon_type = atoi(argument) % 4;
     } else if (ISOPT("pkt-plugin") || ISOPT("module")) {
         insert_data(&g_prog_config.packet_plugin_list, (void*)argument);
     } else if (ISOPT("if-impl")) {
-        COPY_N_ARG_TO(g_prog_config.if_impl, IFNAMSIZ);
+        COPY_N_ARG_TO(g_prog_config.if_impl, IFNAMSIZ - 1);
     } else if (ISOPT("save")) {
         g_prog_config.save_now = 1;
     } else if (ISOPT("help")) {
@@ -160,7 +160,7 @@ static void parse_one_opt(const char* option, const char* argument) {
             g_prog_config.kill_type = KILL_AND_START; /* 结束其他实例，本实例继续运行 */
     } else if (ISOPT("proxy-lan-iface")) {
         g_proxy_config.proxy_on = 1;
-        COPY_N_ARG_TO(g_proxy_config.lan_ifname, IFNAMSIZ);
+        COPY_N_ARG_TO(g_proxy_config.lan_ifname, IFNAMSIZ - 1);
     } else if (ISOPT("auth-round")) {
         g_prog_config.auth_round = atoi(argument);
     } else if (ISOPT("pid-file")) {


### PR DESCRIPTION
1. 把上一次 PR（<https://github.com/updateing/minieap/pull/80>）里的“将最后一字节置零来保证 null-terminated”替换为了 `strndup` 自动置零
2. `IFNAMSIZ` 是包含空终止字符的缓冲区大小，因此需要限制用户输入的网络界面名字符串长度为 `IFNAMSIZ - 1`

> The  <net/if.h> header shall define the following symbolic constant for the length of a buffer containing an interface name (including the terminating NULL character): IF_NAMESIZE Interface name length.