### PR TITLE
chores: use a new systemd services file for personal desktop users when execute make install-desktop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,18 @@ install: minieap minieap.1.gz minieap.service
 	install -m 644 minieap.service $(DESTDIR)$(SYSTEMDDIR)/system/
 	-systemctl enable minieap
 
+.PHONY: install-desktop
+install-desktop: minieap minieap-desktop.service minieap.1.gz
+	install -d $(DESTDIR)$(PREFIX)$(BINDIR)/
+	install -m 755 minieap $(DESTDIR)$(PREFIX)$(BINDIR)/
+	install -d $(DESTDIR)$(SYSCONFDIR)/
+	install -m 644 minieap.conf $(DESTDIR)$(SYSCONFDIR)/
+	install -d $(DESTDIR)$(PREFIX)/share/man/man1/
+	install -m 644 minieap.1.gz $(DESTDIR)$(PREFIX)/share/man/man1/
+	install -d $(DESTDIR)$(SYSTEMDDIR)/system/
+	install -m 644 minieap-desktop.service $(DESTDIR)$(SYSTEMDDIR)/system/minieap.service
+	-systemctl enable minieap
+
 .PHONY: uninstall
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)$(BINDIR)/minieap

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ MiniEAP
 
 注2：如需要链接外部库，请在 `COMMON_CFLAGS`、`COMMON_LDFLAGS`、`LIBS` 中加入合适的 `-I -L -l` 等选项。
 
+## 安装
+
+> [!WARNING]
+> 该小结内容目前仅适用于使用 systemd 的 Linux 系统
+
+运行 `make install` 即可作为 systemd 的 service 进行管理，通过修改 `/etc/minieap.conf` 更改相关参数。
+
+对于个人桌面 Linux 用户，推荐运行 `make install-desktop` 进行安装，修改了 `make install` 的默认 service 模板，增加了睡眠/休眠后唤醒的重新启动和意外退出的自动重启规则。
+
 ## 运行
 
 具体选项请参阅 `minieap -h` 的输出。这里列出必需的几个选项。

--- a/minieap.service.desktop.in
+++ b/minieap.service.desktop.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=MiniEAP Service (Desktop Edition)
+Documentation=man:earlyoom(1) https://github.com/updateing/minieap
+After=network.target suspend.target hibernate.target hybrid-sleep.target
+
+[Service]
+ExecStart=:TARGET:/minieap --conf-file :SYSCONFDIR:/minieap.conf
+StandardOutput=null
+StandardError=syslog
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target suspend.target hibernate.target hybrid-sleep.target


### PR DESCRIPTION
As a desktop user, I encountered an issue where minieap exits after suspend, so I wrote a systemd service to **automatically restart it after sleep** and **updated the corresponding content** in README.

If there's anything inappropriate, I'd really appreciate any feedback ♥️